### PR TITLE
Bug fixes, Add TwitchPlays support

### DIFF
--- a/Assets/LEDEncryption/LEDEncryption.cs
+++ b/Assets/LEDEncryption/LEDEncryption.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 public class LEDEncryption : MonoBehaviour
 {
@@ -136,5 +138,29 @@ public class LEDEncryption : MonoBehaviour
                 GetComponent<KMBombModule>().HandleStrike();
             }
         }
+    }
+
+    KMSelectable[] ProcessTwitchCommand(string command)
+    {
+        var commandList = command.ToLowerInvariant().Split(new[] {" "}, StringSplitOptions.RemoveEmptyEntries);
+        var buttonLookup = new Dictionary<string, int>
+        {
+            {"topleft", 0}, {"lefttop", 0}, {"tl", 0}, {"lt", 0}, {"0", 0},
+            {buttons[0].GetComponentInChildren<TextMesh>().text.ToLowerInvariant(), 0},
+
+            {"topright", 1}, {"righttop", 1}, {"tr", 1}, {"rt", 1}, {"1", 1},
+            {buttons[1].GetComponentInChildren<TextMesh>().text.ToLowerInvariant(), 1},
+
+            {"bottomleft", 2}, {"leftbottom", 2}, {"bl", 2}, {"lb", 2}, {"2", 2},
+            {buttons[2].GetComponentInChildren<TextMesh>().text.ToLowerInvariant(), 2},
+
+            {"bottomright", 3}, {"rightbottom", 3}, {"br", 3}, {"rb", 3}, {"3", 3},
+            {buttons[3].GetComponentInChildren<TextMesh>().text.ToLowerInvariant(), 3},
+        };
+        if (commandList[0] != "press" || commandList.Length != 2 || !buttonLookup.ContainsKey(commandList[1]))
+            return null;
+
+        return new[] {buttons[buttonLookup[commandList[1]]]};
+
     }
 }

--- a/Assets/LEDEncryption/LEDEncryption.cs
+++ b/Assets/LEDEncryption/LEDEncryption.cs
@@ -119,6 +119,11 @@ public class LEDEncryption : MonoBehaviour
         }
         else
         {
+            //Do nothing more once module is solved.
+            //If you wish for strikes to be caused on the incorrect buttons, move this to inside of the
+            //if (isCorrect) block before the layer++ line.
+            if (layer.Equals(layerMultipliers.Length)) return;
+
             Debug.LogFormat("[LED Encryption #{0}] Pressed {1} button, which is {2}.", moduleId, buttonName, isCorrect ? "correct" : "wrong");
             if (isCorrect)
             {

--- a/Assets/LEDEncryption/LEDEncryption.unity
+++ b/Assets/LEDEncryption/LEDEncryption.unity
@@ -37,7 +37,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44692534, g: 0.49678725, b: 0.5750856, a: 1}
+  m_IndirectSpecularColor: {r: 0.44692528, g: 0.4967872, b: 0.5750856, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -90,52 +90,6 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualCellSize: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &347028350
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.0035797693
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0.041477196
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.0068158545
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 439642, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 101964, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-      propertyPath: m_Name
-      value: TestHarness (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8814ea52310d2614a9feda02ec355ae4, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &604743227
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Bug fixes.
* Removed a second instance of TestHarness from the scene, which caused the module to register more than one button press in unity while testing.

* Added a line into OnPress to check to see if the module is already solved.  (If causing a strike on the incorrect buttons is desired, the line can by moved to inside of the IsCorrect statement before the layer++ line.)

Features added
* TwitchPlays support.  Format is !<id> press <button>.  <button> is tl, tr, bl, br,  0-3 in reading order, or the displayed letter itself.